### PR TITLE
Fix some minor spelling errors.

### DIFF
--- a/README.org
+++ b/README.org
@@ -51,7 +51,7 @@ keep the awesome flowing as fast as possible.
 
 ** License information & legalities.
 
-My opinion on articulate-lisp.com's licencing is this: it should be easy to grab bits and pieces and easy to fork if
+My opinion on articulate-lisp.com's licensing is this: it should be easy to grab bits and pieces and easy to fork if
 the author disappears. After some careful reading, I selected...
 
 - GPL3 for the documentation itself. 

--- a/env~ccl-setup.md
+++ b/env~ccl-setup.md
@@ -12,7 +12,7 @@ I'll defer to their instructions for
 
 Of particular interest is that it works on the PPC and ARM architectures; this
 can be of use to embedded system developers. It is possible to get
-[CCL working on the Rasperry Pi](http://lispm.dyndns.org/ccl), for instance.
+[CCL working on the Raspberry Pi](http://lispm.dyndns.org/ccl), for instance.
 
 CCL is particularly well-developed on Mac OS X, including a Cocoa bridge and an
 IDE. It's also a good choice on Windows as it supports native (Win32) threads.

--- a/env~lispworks-setup.md
+++ b/env~lispworks-setup.md
@@ -16,7 +16,7 @@ fill out the form, and download it.
 
 It installs in the usual way for an OSX or Windows application.
 
-The user is recomended to review the LispWorks manual for operation of
+The user is recommended to review the LispWorks manual for operation of
 the system.
 
 Notes

--- a/examples~trotter-walkthrough.md
+++ b/examples~trotter-walkthrough.md
@@ -1,4 +1,4 @@
-% Trotter Walkthough
+% Trotter Walkthrough
 %
 %
 
@@ -49,7 +49,7 @@ the URL.
 ```
 
 
-Next, a predicte to check to see if our data is ASCII. While Common
+Next, a predicate to check to see if our data is ASCII. While Common
 Lisp can handle Unicode data, this is a sample program, and the
 complexities of Unicode can be deferred.
 
@@ -120,7 +120,7 @@ Lisp condition system; it serves as the "try" block in this
 situation. The list of errors below form the "catch" blocks. The
 interested reader is referred to [the quicklinks
 section](quicklinks.html) for more resources. Note that the errors are
-typical network errors- timouts, stream errors, encoding errors.
+typical network errors- timeouts, stream errors, encoding errors.
 
 The first form in `HANDLER-CASE` requests in the url and assigns it to
 page.  Supposing we got something, we make sure it's an ascii page; if
@@ -128,7 +128,7 @@ so, we then find all the url-ish looking things, using the previously
 defined global. Supposing that the page is, indeed, a string, we
 return it, otherwise we convert the octets to a string and return
 that. N.b.: Common Lisp makes a difference between strings and vectors
-of bytes.  Of course, if an error occured, the `HANDLER-CASE` will
+of bytes.  Of course, if an error occurred, the `HANDLER-CASE` will
 route to the known conditions.
 
 Note that in one case, `#+sbcl` is present; this is a Common Lisp

--- a/initial~abcs.md
+++ b/initial~abcs.md
@@ -31,7 +31,7 @@ but boot faster. One common deployment strategy involves saving a
 preloaded *image* and executing it on demand.
 
 
-Most Lisp work is done within the Emacs/SLIME mileau; however,
+Most Lisp work is done within the Emacs/SLIME milieu; however,
 IDE's like LispWorks or Allegro Common Lisp offer similar
 functionality.
 
@@ -104,7 +104,7 @@ Popular libraries that the author have not used include:
 
 * lparallel  - a library for parallel programming
 
-* usocket - TCP socket libary
+* usocket - TCP socket library
 
 
 For snippets and code samples, please see the Snippets in the Examples

--- a/initial~basic-project.md
+++ b/initial~basic-project.md
@@ -4,7 +4,7 @@
 
 We are going to assume that your first project is a small standalone
 program using one of the common libraries for Common Lisp. Since
-Common Lisp is a general purpose high-level programming langugage, it
+Common Lisp is a general purpose high-level programming language, it
 can handle any common high-level language task.
 
 Common libraries are installed using [Quicklisp][Quicklisp]!

--- a/initial~new-project.md
+++ b/initial~new-project.md
@@ -25,7 +25,7 @@ A one-file project has these characteristics:
 # Introduction to ASDF
 
 ASDF, also known as Another System Definition Facility, is the modern
-way for defining Common Lisp libaries. It is fully supported by
+way for defining Common Lisp libraries. It is fully supported by
 Quicklisp, and supports adding your own private libraries.
 
 
@@ -62,7 +62,7 @@ Here is a copy of the contents a library's ASD file:
   :version "3.3"
   :maintainer "Paul Nathan"
   :author "Paul Nathan"
-  :licence "LLGPL"
+  :license "LLGPL"
   :description "CL interface to Yahoo's finance API"
   :long-description "Common Lisp interface to Yahoo's finance API, available over the web. See usage.lisp for example code.")
 ```
@@ -104,7 +104,7 @@ $ ls ~/quicklisp/local-projects/cl-yahoo-finance/
 README.txt
 package.lisp
 cl-yahoo-finance.asd
-cl-yahoo-fianance.lisp
+cl-yahoo-finance.lisp
 ```
 
  Any system you put in Quicklisp's "local-projects" is quickloadable:


### PR DESCRIPTION
Hey, here are some fixes for spelling, one in README.org, the rest in the markdown sources.

Let me know if something's not right, please.

Thanks for the http://articulate-lisp.com site!
