### PR TITLE
Expand index.md

### DIFF
--- a/examples~trotter-walkthrough.md
+++ b/examples~trotter-walkthrough.md
@@ -63,25 +63,19 @@ complexities of Unicode can be deferred.
   t)
 ```
 
-Next, we have a *really sloppy* way to see if a URL is going to point
+Next, we have a quick (and dirty) way to see if a URL is going to point
 to a binary. It just looks for a binary file extension in the string.
 
 
 ```Commonlisp
-(defun known-binary (url)
-  (or (search ".png" url)
-       (search ".bmp" url)
-       (search ".jpg" url)
-       (search ".exe" url)
-       (search ".dmg" url)
-       (search ".package" url)
-       (search ".css" url)
-       (search ".ico" url)
-       (search ".gif" url)
-       (search ".dtd" url)
-       (search ".pdf" url)
-       (search ".xml" url)
-       (search ".tgz" url)))
+(defun known-binary-p (url)
+	"Is this url a binary file?"
+	(let ((binaries
+			  '(".png" ".bmp" ".jpg" ".exe" ".dmg" ".package" ".css"
+				   ".ico" ".gif" ".dtd" ".pdf" ".xml" ".tgz")))
+		(dolist (b binaries NIL)
+			(when (search b url)
+				(return T)))))
 ```
 
 The next form is the most complex: `find-links`.
@@ -93,7 +87,7 @@ The next form is the most complex: `find-links`.
 (defun find-links (url)
   "Scrapes links from a URL. Prints to STDOUT if an error is caught"
   (when (and (http-p url)
-             (not (known-binary url)))
+             (not (known-binary-p url)))
     (handler-case
         (let ((page (drakma:http-request url)))
           (when page

--- a/index.md
+++ b/index.md
@@ -2,9 +2,42 @@
 %
 %
 
-how to write Common Lisp in 2014
+*How to write Common Lisp in 2015 -   
+an initiation manual for the uninitiated*
 
-an initiation manual for the uninitiated
+---
+
+## Dear Reader,
+
+One of the key problems in onboarding developers to use modern Common Lisp is the 
+vertical wall of difficulty. Things that are routinely problematic:
+
+*	emacs use. Most people don't use emacs.
+*	Library creation. Putting together ASDF libraries and using them is a fairly
+	horrid experience the first time.
+*	Selection of Lisp system to use, along with an up-to-date discussion of pros
+	and cons.
+*	Putting together serious projects is not commonly discussed.
+
+This site is dedicated to handling these problems. My goal is to put together an 
+introduction/tutorial for practicing professionals and hobbyists from other 
+languages. People who want to get started with Lisp beyond just typing into a REPL.
+Right now, it feels like this information is less disseminated and much less 
+centralized than it otherwise might be. It's not intended to be a HOWTO for Common
+Lisp. That's been covered *quite well*. But it is intended to be a HOWTO on how to 
+put together a Lisp **environment**.
+
+Anyway, I'd like to collaborate with other people to make this a remarkably fine 
+Lisp help site. Contributions are both **accepted** and **welcome**. It's a wholly 
+static site at this point in time - I don't see a need for articulate-lisp.com to 
+have a dynamic backend. Perhaps/probably one of the code examples will be a webapp.
+
+Happy Hacking,
+
+*Paul Nathan*
+
+P.S.: feel free to contact me for anything you like.
+
 
 ---
 

--- a/who.md
+++ b/who.md
@@ -2,7 +2,8 @@
 %
 %
 
-articulate-lisp.com is designed to fill a gap in the current (2012-2014) resources for getting started with Common Lisp. It's the work of
+articulate-lisp.com is designed to fill a gap in the current (2012-2015) 
+resources for getting started with Common Lisp. It's the work of
 one person (Paul Nathan) so far, and represents his best efforts and
 knowledge at this point in time.
 
@@ -11,14 +12,16 @@ mythical best practice, only what has worked for the author in the
 past.
 
 Feedback of all sorts will be gratefully welcomed. Contributions and
-bug reports should be done via the github location for maximum
+bug reports should be done via the Github location for maximum
 coordination.
 
 Happy hacking!
 
 
-*Credit*
+**Credit**
+
+* Some contributions by Daniel Vedder.
 
 * Analytics by [Quantcast](https://www.quantcast.com/), [MixPanel](http://mixpanel.com), and Google. 
 
-* Theme by [Twitter Bootstrap](http://twitter.github.com/bootstrap/)
+* Theme by [Twitter Bootstrap](http://twitter.github.com/bootstrap/).


### PR DESCRIPTION
I found the home page of articulate-lisp.com a little uninformative - it doesn't tell you all that terribly much about what the site is about. So I copy-pasted in (with some minor tweaks) your Github README text, which provides the sort of information I'd be looking for on a front page.

I was just a little confused by your use of the %-sign in the heading of index.md - that's not official Markdown, is it?

(I also amended the web-trotter walk-through page to mirror the new known-binary function.)