### PR TITLE
Fix the new project trotter link

### DIFF
--- a/initial/new-project.html
+++ b/initial/new-project.html
@@ -16,7 +16,7 @@ layout: default
 <ul>
 <li>Small system.</li>
 <li>Relatively common</li>
-<li>An example is the <a href="../src/web-trotter.lisp">web-trotter</a> program.</li>
+<li>An example is the <a href="../examples/src/web-trotter.lisp">web-trotter</a> program.</li>
 </ul>
 <h1 id="introduction-to-asdf">Introduction to ASDF</h1>
 <p>ASDF, also known as Another System Definition Facility, is the modern way for defining Common Lisp libraries. It is fully supported by Quicklisp, and supports adding your own private libraries.</p>


### PR DESCRIPTION
I wasn't able to test this due to docker not working for me for whatever reason.

Got:

````
Unable to find image 'jekyll/stable:latest' locally
Pulling repository docker.io/jekyll/stable
Error: image jekyll/stable:latest not found
````

When running livetest.sh