### PR TITLE
Fix the broken docker scripts

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 # host:guest port map.
-docker run --label=jekyll --label=stable --volume=$(pwd):/srv/jekyll -t -p 127.0.0.1:4000:4000 jekyll/stable jekyll build
+docker run --label=jekyll --label=stable --volume=$(pwd):/srv/jekyll -t -p 127.0.0.1:4000:4000 jekyll/jekyll jekyll build
 
 docker build -t pnathan/articulate-common-lisp:latest .

--- a/livetest.sh
+++ b/livetest.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker run --label=jekyll --label=stable --volume=$(pwd):/srv/jekyll -t -p 127.0.0.1:4000:4000 jekyll/stable jekyll s --baseurl=''
+docker run --label=jekyll --label=stable --volume=$(pwd):/srv/jekyll -p 127.0.0.1:4000:4000 jekyll/jekyll


### PR DESCRIPTION
I am far from a docker expert, but the original scripts were complaining
that jekyll/stable didn't exist. In addition, CTRL+C was not killing the
livetest docker container.

With these changes both things seem to work for me. I recommend manually
testing these yourself before merging.